### PR TITLE
1 issue create common issue templates

### DIFF
--- a/.guthub/ISSUE_TEMPLATES/bug-report.yml
+++ b/.guthub/ISSUE_TEMPLATES/bug-report.yml
@@ -1,0 +1,43 @@
+---
+name: "🐞 Bug Report"
+description: "Report a bug to help improve the project."
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: "### 🐞 Bug Report\nPlease provide a clear and concise description of the problem."
+  - type: input
+    id: bug-summary
+    attributes:
+      label: "Brief Summary"
+      description: "Provide a short summary of the bug."
+      placeholder: "Example: Navigation bar disappears on mobile."
+    validations:
+      required: true
+  - type: textarea
+    id: steps-to-reproduce
+    attributes:
+      label: "Steps to Reproduce"
+      description: "Explain how to reproduce the bug."
+      placeholder: "1. Go to homepage\n2. Click on 'Contact'\n3. See error"
+    validations:
+      required: true
+  - type: textarea
+    id: expected-behavior
+    attributes:
+      label: "Expected Behavior"
+      description: "What should have happened?"
+    validations:
+      required: true
+  - type: textarea
+    id: actual-behavior
+    attributes:
+      label: "Actual Behavior"
+      description: "What actually happened?"
+    validations:
+      required: true
+  - type: textarea
+    id: additional-info
+    attributes:
+      label: "Additional Information"
+      description: "Logs, screenshots, or any other relevant information."

--- a/.guthub/ISSUE_TEMPLATES/feature_request.yml
+++ b/.guthub/ISSUE_TEMPLATES/feature_request.yml
@@ -1,0 +1,31 @@
+# feature_request.yml
+---
+name: "🚀 Feature Request"
+description: "Suggest an improvement or new feature."
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: "### 🚀 Feature Request\nDescribe the feature you would like to see."
+  - type: input
+    id: feature-summary
+    attributes:
+      label: "Brief Summary"
+      description: "Provide a one-line summary of your feature request."
+      placeholder: "Example: Add dark mode support."
+    validations:
+      required: true
+  - type: textarea
+    id: feature-details
+    attributes:
+      label: "Feature Details"
+      description: "Describe the feature and its benefits."
+    validations:
+      required: true
+  - type: textarea
+    id: use-case
+    attributes:
+      label: "Use Case"
+      description: "Explain how this feature will be useful."
+    validations:
+      required: true

--- a/.guthub/ISSUE_TEMPLATES/question.yml
+++ b/.guthub/ISSUE_TEMPLATES/question.yml
@@ -1,0 +1,15 @@
+---
+name: "🙋‍♂️ Question"
+description: "Ask a question related to this project."
+labels: ["question"]
+body:
+  - type: markdown
+    attributes:
+      value: "### ❓ Question\nAsk your question clearly and concisely."
+  - type: textarea
+    id: question-details
+    attributes:
+      label: "Your Question"
+      description: "Provide a detailed question."
+    validations:
+      required: true

--- a/.guthub/ISSUE_TEMPLATES/task.yml
+++ b/.guthub/ISSUE_TEMPLATES/task.yml
@@ -1,0 +1,34 @@
+name: "✅ Task"
+description: "Track a task or to-do item."
+labels: ["task"]
+body:
+  - type: markdown
+    attributes:
+      value: "### ✅ Task\nOutline the task and any relevant details."
+  - type: input
+    id: task-summary
+    attributes:
+      label: "Task Summary"
+      description: "Provide a brief summary of the task."
+      placeholder: "Example: Implement caching for API responses."
+    validations:
+      required: true
+  - type: textarea
+    id: task-details
+    attributes:
+      label: "Task Details"
+      description: "Describe the task in detail, including any dependencies or considerations."
+    validations:
+      required: true
+  - type: textarea
+    id: expected-outcome
+    attributes:
+      label: "Expected Outcome"
+      description: "What is the desired result of completing this task?"
+    validations:
+      required: true
+  - type: textarea
+    id: additional-notes
+    attributes:
+      label: "Additional Notes"
+      description: "Any extra context, links, or references related to the task."


### PR DESCRIPTION
# Description
This pull request adds common GitHub issue templates for the following types:

# Task
Bug Report
Question
Feature Request
The templates are created using both YAML and form syntax.

# Changes
- Added task.yml for task issue template
- Added bug_report.yml for bug report issue template
- Added question.yml for question issue template
- Added feature_request.yml for feature request issue template

# How to Test
Navigate to the "Issues" tab in the repository.
Click on "New Issue."
Verify that the new templates are available for selection.
